### PR TITLE
Be more explicit about the scattering length database

### DIFF
--- a/src/control/database.cpp
+++ b/src/control/database.cpp
@@ -44,7 +44,8 @@ void Database::read_xml(std::string filename) {
   XMLInterface xmli(filename);
 
   xmli.dump(config);
-  Info::Inst()->write("Reading database...");
+ Info::Inst()->write("Reading database from file: " + filename);
+
   // now read the database
 
   // START OF database section //

--- a/src/control/database.cpp
+++ b/src/control/database.cpp
@@ -44,7 +44,7 @@ void Database::read_xml(std::string filename) {
   XMLInterface xmli(filename);
 
   xmli.dump(config);
- Info::Inst()->write("Reading database from file: " + filename);
+  Info::Inst()->write("Reading database from file: " + filename);
 
   // now read the database
 

--- a/tests/waterdyn4/db.xml
+++ b/tests/waterdyn4/db.xml
@@ -1,3 +1,0 @@
-<root xmlns:xi="http://www.w3.org/2001/XInclude">
-  <xi:include href="database/db-neutron-incoherent.xml"/>
-</root>

--- a/tests/waterdyn4/scatter.xml
+++ b/tests/waterdyn4/scatter.xml
@@ -12,6 +12,9 @@
 			</frameset>
 		</framesets>
 	</sample>
+ 	<database>
+	    	<file>database/db-neutron-incoherent.xml</file>
+	</database>
 	<scattering>
 	    <type>self</type>		
 	    <dsp>


### PR DESCRIPTION
So far, sassena reads a file "db.xml" in the same folder as scatter.xml which links to n/x coh/inc scattering lengths. There is no indication of which scattering lengths sassena actually used in the computation. Switching between coh/inc requires changes in both files. Since the database is loaded without further notification, there is no second chance to realize that one forgot to adjust db.xml.

We propose to be more explicit about which scattering lengths should be / are used:
* print the name of the loaded database (just like sassena is printing the name of the loaded trajectory)
* include an explicit link to the database in scatter.xml (using an existing but undocumented feature)
* delete db.xml to avoid confusion.

An additional advantage of this method is that the database does not have to be copied each time a new simulation is evaluated: it can be kept at a central place and the absolute or relative path to it can be given in each scatter.xml.