### PR TITLE
adding some more examples for xml files

### DIFF
--- a/tests/waterdyn4/n_dyn_coh.xml
+++ b/tests/waterdyn4/n_dyn_coh.xml
@@ -14,31 +14,36 @@
   </sample>
 
   <database>
-    <file>database/db-neutron-incoherent.xml</file>
+    <file>database/db-neutron-coherent.xml</file>
   </database>
 
   <scattering>
-    <type>self</type>
+    <type>all</type>
     <dsp>
       <type>autocorrelate</type>
       <method>fftw</method>
     </dsp>
     <vectors>
-      <type>single</type>
-      <single>
-        <x>1.0</x> <y>0.0</y> <z>0.0</z>
-      </single> 
+      <type>scans</type>
+      <scans>
+        <scan>
+          <x>1.0</x> <y>0.0</y> <z>0.0</z>
+          <from>0.1</from>
+          <to>5.0</to>
+          <points>50</points>
+        </scan>
+      </scans>
     </vectors>
     <average>
       <orientation>
         <type>vectors</type>
-          <vectors>          
-            <type>sphere</type>
-            <algorithm>boost_uniform_on_sphere</algorithm>
-            <resolution>100</resolution>
-          </vectors>
-        </orientation>
-      </average>
+        <vectors>
+          <type>sphere</type>
+          <algorithm>boost_uniform_on_sphere</algorithm>
+          <resolution>100</resolution>
+        </vectors>
+      </orientation>
+    </average>
   </scattering>
 
   <stage>
@@ -46,3 +51,4 @@
   </stage>
 
 </root>
+

--- a/tests/waterdyn4/n_dyn_inc.xml
+++ b/tests/waterdyn4/n_dyn_inc.xml
@@ -18,27 +18,32 @@
   </database>
 
   <scattering>
-    <type>self</type>
+    <type>all</type>
     <dsp>
       <type>autocorrelate</type>
       <method>fftw</method>
     </dsp>
     <vectors>
-      <type>single</type>
-      <single>
-        <x>1.0</x> <y>0.0</y> <z>0.0</z>
-      </single> 
+      <type>scans</type>
+      <scans>
+        <scan>
+          <x>1.0</x> <y>0.0</y> <z>0.0</z>
+          <from>0.1</from>
+          <to>5.0</to>
+          <points>50</points>
+        </scan>
+      </scans>
     </vectors>
     <average>
       <orientation>
         <type>vectors</type>
-          <vectors>          
-            <type>sphere</type>
-            <algorithm>boost_uniform_on_sphere</algorithm>
-            <resolution>100</resolution>
-          </vectors>
-        </orientation>
-      </average>
+        <vectors>
+          <type>sphere</type>
+          <algorithm>boost_uniform_on_sphere</algorithm>
+          <resolution>100</resolution>
+        </vectors>
+      </orientation>
+    </average>
   </scattering>
 
   <stage>
@@ -46,3 +51,4 @@
   </stage>
 
 </root>
+

--- a/tests/waterdyn4/n_dyn_inc.xml
+++ b/tests/waterdyn4/n_dyn_inc.xml
@@ -18,7 +18,7 @@
   </database>
 
   <scattering>
-    <type>all</type>
+    <type>self</type>
     <dsp>
       <type>autocorrelate</type>
       <method>fftw</method>

--- a/tests/waterdyn4/n_str_coh.xml
+++ b/tests/waterdyn4/n_str_coh.xml
@@ -1,0 +1,53 @@
+<root>
+
+  <sample>
+    <structure>
+      <file>sample.pdb</file>
+      <format>pdb</format>
+    </structure>
+    <framesets>
+      <frameset>
+        <file>sample.dcd</file>
+        <format>dcd</format>
+      </frameset>
+    </framesets>
+  </sample>
+
+  <database>
+    <file>database/db-neutron-coherent.xml</file>
+  </database>
+
+  <scattering>
+    <type>all</type>
+    <dsp>
+      <type>square</type>
+    </dsp>
+    <vectors>
+      <type>scans</type>
+      <scans>
+        <scan>
+          <x>1.0</x> <y>0.0</y> <z>0.0</z>
+          <from>0.0</from>
+          <to>30.0</to>
+          <points>301</points>
+        </scan>
+      </scans>
+    </vectors>
+    <average>
+      <orientation>
+        <type>vectors</type>
+        <vectors>
+          <type>sphere</type>
+          <algorithm>boost_uniform_on_sphere</algorithm>
+          <resolution>1000</resolution>
+        </vectors>
+      </orientation>
+    </average>
+  </scattering>
+
+  <stage>
+    <threads>1</threads>
+  </stage>
+
+</root>
+

--- a/tests/waterdyn4/x_str_coh.xml
+++ b/tests/waterdyn4/x_str_coh.xml
@@ -1,0 +1,53 @@
+<root>
+
+  <sample>
+    <structure>
+      <file>sample.pdb</file>
+      <format>pdb</format>
+    </structure>
+    <framesets>
+      <frameset>
+        <file>sample.dcd</file>
+        <format>dcd</format>
+      </frameset>
+    </framesets>
+  </sample>
+
+  <database>
+    <file>database/db-xray-coherent.xml</file>
+  </database>
+
+  <scattering>
+    <type>all</type>
+    <dsp>
+      <type>square</type>
+    </dsp>
+    <vectors>
+      <type>scans</type>
+      <scans>
+        <scan>
+          <x>1.0</x> <y>0.0</y> <z>0.0</z>
+          <from>0.0</from>
+          <to>30.0</to>
+          <points>301</points>
+        </scan>
+      </scans>
+    </vectors>
+    <average>
+      <orientation>
+        <type>vectors</type>
+        <vectors>
+          <type>sphere</type>
+          <algorithm>boost_uniform_on_sphere</algorithm>
+          <resolution>1000</resolution>
+        </vectors>
+      </orientation>
+    </average>
+  </scattering>
+
+  <stage>
+    <threads>1</threads>
+  </stage>
+
+</root>
+


### PR DESCRIPTION
I've switched the indentation in the xml files from tab to space
Also, I've added 4 more files to the examples:
	new file:   n_dyn_coh.xml -- neutron scattering, dynamics (fqt), coherent scattering factors
	new file:   n_dyn_inc.xml -- neutron scattering, dynamics (fqt), incoherent scattering factors
	new file:   n_str_coh.xml -- neutron scattering, structure (fq), coherent scattering factors
	new file:   x_str_coh.xml -- x-ray scattering, structure (fq), coherent scattering factors
The options (autocorrelate vs square, 100/1000 vectors) are what I understood as recommended values in the sassena publication (Table 2).